### PR TITLE
add manifest to build for firefox

### DIFF
--- a/src/manifest.json.firefox
+++ b/src/manifest.json.firefox
@@ -1,0 +1,29 @@
+{
+  "name": "Faceit Exts",
+  "description": "Faceit Exts is a extension improve experience and adds some features",
+  "version": "1.0.0",
+  "manifest_version": 2,
+  "permissions": [
+    "https://api.faceit.com/"
+  ],
+  "icons": {
+    "16": "icon16.png",
+    "48": "icon48.png",
+    "128": "icon128.png"
+  },
+  "content_scripts": [
+    {
+      "run_at": "document_end",
+      "matches": ["https://www.faceit.com/*"],
+      "js": ["contentScript.bundle.js"]
+    }
+  ],
+  "browser_action": {
+    "default_icon": "icon48.png",
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "scripts": ["background.bundle.js"],
+    "persistent": false
+  }
+}


### PR DESCRIPTION
- Because Firefox doesn't support manifest v3, we use another manifest file to build firefox add-on