### PR TITLE
Improve profile's stats page

### DIFF
--- a/src/helpers/faceit-api.js
+++ b/src/helpers/faceit-api.js
@@ -2,7 +2,7 @@ import pMemoize from 'p-memoize'
 import camelcaseKeys from 'camelcase-keys'
 import * as dateFns from 'date-fns'
 import Cookies from 'js-cookie'
-import { mapTotalStatsMemoized, mapAverageStatsMemoized } from './stats'
+import { mapAverageStatsMemoized } from './stats'
 import pRetry from 'p-retry'
 
 export const CACHE_TIME = 600000
@@ -82,18 +82,8 @@ export const getPlayerStats = async (userId, game, size = 20) => {
     return false
   }
 
-  let totalStats = await fetchApiMemoized(
-    `/stats/v1/stats/users/${userId}/games/${game}`
-  )
-
-  if (!totalStats || Object.keys(totalStats).length === 0) {
-    return null
-  }
-
-  totalStats = mapTotalStatsMemoized(totalStats.lifetime)
-
   let averageStats = await fetchApiMemoized(
-    `/stats/v1/stats/time/users/${userId}/games/${game}?size=${size}`
+    `/stats/v1/stats/time/users/${userId}/games/${game}?page=0&size=${size}`
   )
 
   if (!averageStats || !Array.isArray(averageStats)) {
@@ -109,7 +99,6 @@ export const getPlayerStats = async (userId, game, size = 20) => {
   averageStats = mapAverageStatsMemoized(averageStats)
 
   return {
-    ...totalStats,
     ...averageStats
   }
 }

--- a/src/pages/Content/modules/header-level-progress/index.jsx
+++ b/src/pages/Content/modules/header-level-progress/index.jsx
@@ -17,7 +17,12 @@ export const FeatureHeaderLevelProgress = async () => {
     return
   }
 
-  const mainHeaderActionsElement = document.querySelector("div[ui-view='header']").querySelector('#main-header-height-wrapper').shadowRoot.querySelector("#__next").querySelector("#main-header-height-wrapper").querySelector('div')
+  let mainHeaderActionsElement = null
+  try {
+    mainHeaderActionsElement = document.querySelector("div[ui-view='header']").querySelector('#main-header-height-wrapper').shadowRoot.querySelector("#__next").querySelector("#main-header-height-wrapper").querySelector('div')
+  } catch (error) {
+    return
+  }
 
   if (!mainHeaderActionsElement) {
     return

--- a/src/pages/Content/modules/player-profile-extended-stats/index.js
+++ b/src/pages/Content/modules/player-profile-extended-stats/index.js
@@ -52,6 +52,7 @@ export const PlayerProfileExtendedStats = async parentElement => {
   }
 
   const {
+    winRate,
     averageKills,
     averageHeadshots,
     averageKDRatio,
@@ -63,7 +64,15 @@ export const PlayerProfileExtendedStats = async parentElement => {
       <div style={{ display: 'flex', gap: 16 }}>
         <div style={{ flex: 2 }}>
           {createSectionTitleElement({ title: 'Last 20 Matches Statistics' })}
-          <div style={{ display: 'flex', gap: 16 }}>
+          <div style={{ display: 'flex', gap: 14 }}>
+            {createKeyStatElement({
+              key: 'Elo',
+              stat: player.games.csgo.faceitElo
+            })}
+            {createKeyStatElement({
+              key: 'WIN RATE %',
+              stat: winRate
+            })}
             {createKeyStatElement({
               key: 'Average Kills',
               stat: averageKills

--- a/src/pages/Content/modules/player-profile-extended-stats/index.js
+++ b/src/pages/Content/modules/player-profile-extended-stats/index.js
@@ -41,9 +41,7 @@ export const PlayerProfileExtendedStats = async parentElement => {
 
   const nickname = getPlayerProfileNickname()
   const game = getPlayerProfileStatsGame()
-  const { infractions = {}, ...player } = await getPlayer(nickname)
-
-  const { afk = 0, leaver = 0 } = infractions
+  const { ...player } = await getPlayer(nickname)
 
   const playerStats = await getPlayerStats(player.id, game)
 
@@ -91,19 +89,6 @@ export const PlayerProfileExtendedStats = async parentElement => {
             })}
           </div>
           <div />
-        </div>
-        <div style={{ flex: 1 }}>
-          {createSectionTitleElement({ title: 'Other Statistics' })}
-          <div style={{ display: 'flex', gap: 16 }}>
-            {createKeyStatElement({
-              key: 'AFK Times',
-              stat: afk
-            })}
-            {createKeyStatElement({
-              key: 'Leave Times',
-              stat: leaver
-            })}
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Describe the feature**
 - remove lifetime stats
 - ignore the error when the header is not found
 - re-show the last 20 matches' stats, add current elo and win rate
 - remove unused section `other stats` ( already show it at `BAN` section in profile page )

**Screenshots**
If applicable, add screenshots to explain your feature.

**Tested successfully on Browsers below:**

- Chrome v108
- Firefox v1.0
- Brave v1.0

**Additional context**
Add any other context about the feature here.
